### PR TITLE
Added Engineer II role and restructured Engineer and Senior Engineer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repo contains a list of Engineering titles, roles, and associated responsib
 
 [Makers path](makers/makers_path.md)
 * [Engineer](makers/engineer.md)
+* [Engineer II](makers/engineer_ii.md)
 * [Senior Engineer](makers/senior_engineer.md)
 * [Staff Engineer](makers/staff_engineer.md)
 * [Senior Staff Engineer](makers/senior_staff_engineer.md)

--- a/makers/engineer.md
+++ b/makers/engineer.md
@@ -2,26 +2,15 @@ Engineer
 --------
 
 ### Should have
-* Core language competencies
-* Fundamental computer science competency
-* Experience working on a team
+* Learning core language competency in at least one language
+* Experience working on a team or in a group academic setting
 * A thirst for knowledge and continuous learning
 * A connection to Meetup’s mission and values
 
 ### Is expected to
-* Communicate well with, and give direct and candid feedback to, manager and all members of the team
-* Alert manager/team to any issues preventing their work from being accomplished
-* Actively pursue improving engineering skills, including but not limited to problem solving, writing readable/testable/efficient code, mastering technology in our stack, and anticipating scaling issues.
-* Perform well-defined engineering tasks in a reasonable amount of time; doesn’t get caught up in the unknown, works to figure it out
-* Demonstrate confidence proposing a final recommendation
+* Communicate well with all members of the team
+* Perform well-defined engineering tasks; doesn’t get caught up in the unknown, works to figure it out, asks questions
+* Alert manager/team to any issues preventing their work from being accomplished, asks for help
+* Actively pursue improving engineering skills, including but not limited to problem solving, writing readable/testable/efficient code, mastering technology in our stack, and learning to anticipate scaling issues.
 * Demonstrate ability to learn from mistakes
-* Lean into challenges when they offer the potential to create large impact, and does so with productivity and positivity
-* Become an expert with at least one area or domain of the code/product
-* Follow through with the code they write and make sure it is always tested/launched/easy to maintain
-* Review other engineers’ code and provide constructive feedback
-* Launch software that puts customer needs first and increases customer satisfaction
-* Help grow the engineering team through involvement in the technology community (conferences, meetups, blog posts, open source projects, etc) and referrals
-* Have their actions reflect individual, team, discipline, and company goals, and say “no” to projects that don’t align with their goals
-* Be able to launch to production independently (if needed)
-* Have production access and use it responsibly
-* Demonstrate support of a team/company decision
+* Seek to tie stories back to user value & impact for our members & organizers

--- a/makers/engineer_ii.md
+++ b/makers/engineer_ii.md
@@ -1,0 +1,29 @@
+Engineer II
+===============
+
+*Same as Engineer, but also...*
+
+### Should have
+
+* Successfully performed the role of an Engineer at Meetup or equivalent role elsewhere
+* Core language competency in at least one language
+* Experience working on a team in a professional setting
+* Demonstrated ability to collaborate well with a team
+* Demonstrated ability to learn from mistakes
+* Demonstrated ability to unblock themselves, asks for help where necessary
+* Demonstrated good communication skills with teammates and shows a good degree of emotional and professional maturity.
+
+### Is expected to
+
+* Contribute meaningfully to the definition of stories
+* Pick up any story & suggest a solution for completing it
+* Lean into challenges when they offer the potential to create large impact, and does so with productivity and positivity
+* Be able to dive in to an area of the code/product that they’re not familiar with & make changes
+* Make sure their code is readable & easy to maintain
+* Make sure their code is tested appropriately
+* Review other engineers’ code and provide constructive feedback
+* Help grow the engineering team through involvement in the technology community (conferences, meetups, blog posts, open source projects, etc) and referrals
+* Monitor changes in production & rollback if necessary
+* Have production access and use it responsibly
+* Pair often and provide some guidance to more junior engineers
+* Review pull requests from engineers of a range of abilities

--- a/makers/senior_engineer.md
+++ b/makers/senior_engineer.md
@@ -1,28 +1,29 @@
 Senior Engineer
 ===============
 
-*Same as Engineer, but also...*
+*Same as Engineer II, but also...*
 
 ### Should have
 
-* Successfully performed the role of an Engineer at Meetup or equivalent role elsewhere
+* Successfully performed the role of a Mid-Level Engineer at Meetup or equivalent role elsewhere
 * Performed work that was evaluated to be done at ‘high quality’ by peers
+* Demonstrated ability to collaborate well across teams
 * Succeeded as an engineer when presented with projects of increasing complexity over time across multiple areas or domains of the code/product
-* Demonstrated ability to learn from mistakes
-* Demonstrated ability to unblock themselves and other team members  
+* Demonstrated ability to unblock themselves and other team members
 * Earned a high level of trust amongst team to own a task/project without needing much supervision
-* Shown they take responsibility for their code: follow through with it and address any issues that result from it in the future
+* Demonstrated ability to anticipate how contributions can affect larger architecture, developing risk mitigation and contingency plans
 * A high level of understanding about where their work fits in and how to be useful and successful on their team
 * A high level of craftsmanship about their work, the end experience of the user, and impact on overall product
-* Demonstrated good communication skills with other engineers and teammates, including being productive with their emotions; proposes solutions when articulating problems
+* Demonstrated excellent communication skills with technical and non-technical teammates and shows a high level of emotional and professional maturity.
+* Proposes solutions when articulating problems
 
 ### Is expected to
 
-* Become an expert with multiple areas or domains of the code/product
-* Show curiosity to not only learn new things but fully understand how they work 
+* Be familiar  with multiple areas or domains of the code/product
+* Be able to dive in to any area of the code/product that they’re not familiar with & make changes, guide others in how to do this
+* Show curiosity to not only learn new things but fully understand how they work
 * Be highly productive - have a reputation for getting things done quickly and efficiently
 * Be a mentor for other engineers
-* Require very little oversight from manager/team leads
 * Own and complete full projects beginning with identifying and communicating the problems to be solved, getting and incorporating feedback on proposed architectural solutions, and making a final decision as the owner of a project.
 * Deconstruct a problem into an executable action plan for themselves and other engineers - also perform them in a high quality way without issue
 * Consistently tie back a project to a team goal

--- a/makers/senior_engineer.md
+++ b/makers/senior_engineer.md
@@ -5,7 +5,7 @@ Senior Engineer
 
 ### Should have
 
-* Successfully performed the role of a Mid-Level Engineer at Meetup or equivalent role elsewhere
+* Successfully performed the role of an Engineer II at Meetup or equivalent role elsewhere
 * Performed work that was evaluated to be done at ‘high quality’ by peers
 * Demonstrated ability to collaborate well across teams
 * Succeeded as an engineer when presented with projects of increasing complexity over time across multiple areas or domains of the code/product


### PR DESCRIPTION
The purpose of this PR is to add an intermediate role sitting between Engineer and Senior Engineer. This new role is called "Engineer II".

In order to create this role, I had to modify elements of the Engineer and Senior Engineer roles, which is why all 3 have been updated here.

The content of these changes has already been approved by People Partners and by Engineering leadership.